### PR TITLE
Add Gtest Testing Framework to Project

### DIFF
--- a/src/Workspace
+++ b/src/Workspace
@@ -1,0 +1,6 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "gtest",
+    remote = "https://github.com/google/googletest",
+)


### PR DESCRIPTION
Add Gtest to workspace to make the framework ready for implementing tests.